### PR TITLE
fix(umami): align URL stats with share API filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oddmisc",
-  "version": "1.1.6",
+  "version": "1.2.1",
   "description": "杂七杂八奇怪小工具 npm 包 — Umami 分享链接统计读取与 Astro 集成",
   "homepage": "https://github.com/yCENzh/oddmisc#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- Fixed `getPageStatsByUrl` to parse a full URL into the actual Umami stats filters (`path` + `hostname`) instead of sending the ignored `url` query parameter.
- Added `hostname` support to stats query parameters and expanded `MetricType` to match the currently documented Umami v2 metric types (`entry`, `exit`, `query`, `channel`, `domain`, `hostname`, `distinctId`, etc.).
- Updated tests and README to document the behavior discovered by checking the official cloud share page and the self-hosted share page.
- Addressed Devin Review by adding the missing `query` metric type and widening metric values to `string | null`, matching observed self-hosted `type=query` responses.

## Review & Testing Checklist for Human
- [ ] Verify `getPageStatsByUrl('https://your-domain/path?query=...')` returns page-specific stats on your own Umami share link, especially when one website tracks multiple hostnames.
- [ ] Confirm callers that used `options.path` with `getPageStatsByUrl` do not rely on overriding the parsed path; the method now intentionally prioritizes the URL-derived path/hostname.
- [ ] Run a real integration check with both provided share URLs and compare `getPageStatsByUrl` against the same path in the Umami UI.

### Notes
- Verified against the provided pages: official `cloud.umami.is/analytics/us/share/pNrbzntfHm1jet1f` and self-hosted `umami.14131413.xyz/share/JsbYvsDKnsL` both ignore `url=` on `/stats`; `path=` filters correctly, and `hostname=` further narrows multi-host self-hosted data.
- Verified `type=query` returns 200 on both provided endpoints; self-hosted can return `{ x: null, y: ... }`.
- Local checks passed after the review fix: `pnpm test`, `pnpm exec tsc --noEmit`, `pnpm build`.